### PR TITLE
Feat/terraform docdb elasticache

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -103,33 +103,33 @@ jobs:
         working-directory: terragrunt/env/staging/${{ matrix.module }}
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
-  # terragrunt-apply-group2:
-  #   if: github.repository == 'cds-snc/cra-arc-upd-tbpc'
-  #   needs: terragrunt-apply-group1
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - module: database
-  #         - module: elasticache
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  terragrunt-apply-group2:
+    if: github.repository == 'cds-snc/cra-arc-upd-tbpc'
+    needs: terragrunt-apply-group1
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: database
+          - module: elasticache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Setup Terraform Tools
-  #       uses: cds-snc/terraform-tools-setup@v1
+      - name: Setup Terraform Tools
+        uses: cds-snc/terraform-tools-setup@v1
 
-  #     - name: Configure aws credentials using OIDC
-  #       uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
-  #       with:
-  #         role-to-assume: arn:aws:iam::211125499457:role/cra-arc-upd-tbpc-apply
-  #         role-session-name: TFApply-group2
-  #         aws-region: ${{ env.AWS_REGION }}
+      - name: Configure aws credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::211125499457:role/cra-arc-upd-tbpc-apply
+          role-session-name: TFApply-group2
+          aws-region: ${{ env.AWS_REGION }}
 
-  #     - name: Apply ${{ matrix.module }}
-  #       working-directory: terragrunt/env/staging/${{ matrix.module }}
-  #       run: terragrunt apply --terragrunt-non-interactive -auto-approve
+      - name: Apply ${{ matrix.module }}
+        working-directory: terragrunt/env/staging/${{ matrix.module }}
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
   # terragrunt-apply-group3:
   #   if: github.repository == 'cds-snc/cra-arc-upd-tbpc'

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -79,10 +79,10 @@ jobs:
         include:
           # List the environment directories under terragrunt/env/staging/
           # - module: api_gateway
-          # - module: database
+          - module: database
           - module: ecr
           # - module: ecs
-          # - module: elasticache
+          - module: elasticache
           - module: network
           - module: s3
           # - module: s3_web_files

--- a/terragrunt/aws/database/documentdb.tf
+++ b/terragrunt/aws/database/documentdb.tf
@@ -1,0 +1,49 @@
+#
+# Terraform code to create an Amazon DocumentDB cluster 
+#
+
+data "aws_ssm_parameter" "docdb_username" {
+  name = "DOCDB_USERNAME"
+}
+
+data "aws_ssm_parameter" "docdb_password" {
+  name = "DOCDB_PASSWORD"
+}
+
+module "cra_upd_documentdb" {
+  source = "github.com/cds-snc/terraform-modules//DocumentDB?ref=v10.4.4"
+
+  database_name          = "upd"
+  billing_code           = var.billing_code
+  master_username        = data.aws_ssm_parameter.docdb_username.value
+  master_password        = data.aws_ssm_parameter.docdb_password.value
+  subnet_ids             = var.vpc_private_subnet_ids
+  vpc_security_group_ids = [aws_security_group.cra_upd_docdb_sg.id]
+  storage_encrypted      = true
+  instance_class         = var.docdb_instance_class
+  cluster_family         = "docdb5.0"
+  cluster_size           = var.docdb_instance_count
+  deletion_protection    = true
+  backup_window          = var.docdb_backup_window
+  storage_type           = var.docdb_storage_type
+
+  parameters = [
+    {
+      apply_method = "pending-reboot"
+      name         = "tls"
+      value        = "enabled"
+    },
+    {
+      name  = "default_collection_compression"
+      value = "enabled"
+    },
+    {
+      name  = "profiler"
+      value = "disabled" # most queries will be considered "slow operations", so we'll disable this
+    },
+    {
+      name  = "ttl_monitor"
+      value = "disabled" # we won't be using TTL indexes, so we'll disable this to save on compute
+    }
+  ]
+}

--- a/terragrunt/aws/database/inputs.tf
+++ b/terragrunt/aws/database/inputs.tf
@@ -1,0 +1,38 @@
+variable "vpc_id" {
+  description = "The VPC id of the CRA UPD app"
+  type        = string
+}
+
+variable "vpc_private_subnet_ids" {
+  description = "The private subnet ids of the VPC"
+  type        = list(any)
+}
+
+variable "vpc_cidr_block" {
+  description = "The cidr block of the VPC"
+  type        = string
+}
+
+variable "docdb_instance_class" {
+  description = "The instance class of the DocumentDB cluster"
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "docdb_instance_count" {
+  description = "The number of instances in the DocumentDB cluster"
+  type        = number
+  default     = 1
+}
+
+variable "docdb_storage_type" {
+  description = "The storage type to associate with the DB cluster."
+  type        = string
+  default     = "iopt1" # Use I/O-optimized storage by default, because our workload is I/O intensive
+}
+
+variable "docdb_backup_window" {
+  description = "(Optional, default is `04:00-06:00`). Daily time range that backups execute (UTC time). Default is at 00:00am - 02:00am EST."
+  type        = string
+  default     = "04:00-06:00"
+}

--- a/terragrunt/aws/database/outputs.tf
+++ b/terragrunt/aws/database/outputs.tf
@@ -1,0 +1,24 @@
+output "docdb_cluster_id" {
+  description = "The document db cluster id"
+  value       = module.cra_upd_documentdb.docdb_cluster_id
+}
+
+output "docdb_cluster_arn" {
+  description = "The document db cluster arn"
+  value       = module.cra_upd_documentdb.docdb_cluster_arn
+}
+
+output "docdb_endpoint" {
+  description = "The document db cluster endpoint"
+  value       = module.cra_upd_documentdb.docdb_endpoint
+}
+
+output "docdb_sg_id" {
+  description = "The security group id of the document db database"
+  value       = aws_security_group.cra_upd_docdb_sg.id
+}
+
+output "docdb_egress_sg_id" {
+  description = "ID of the security group to allow egress to DocumentDB"
+  value       = aws_security_group.cra_upd_docdb_egress_sg.id
+}

--- a/terragrunt/aws/database/outputs.tf
+++ b/terragrunt/aws/database/outputs.tf
@@ -11,6 +11,7 @@ output "docdb_cluster_arn" {
 output "docdb_endpoint" {
   description = "The document db cluster endpoint"
   value       = module.cra_upd_documentdb.docdb_endpoint
+  sensitive   = true
 }
 
 output "docdb_sg_id" {

--- a/terragrunt/aws/database/security_groups.tf
+++ b/terragrunt/aws/database/security_groups.tf
@@ -1,0 +1,19 @@
+resource "aws_security_group" "cra_upd_docdb_sg" {
+  name        = "cra-upd-docdb-sg"
+  description = "Ingress to DocumentDB Security Group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "Allow ingress to DocumentDB"
+    from_port       = 27017
+    to_port         = 27017
+    protocol        = "tcp"
+    security_groups = [aws_security_group.cra_upd_docdb_egress_sg.id]
+  }
+}
+
+resource "aws_security_group" "cra_upd_docdb_egress_sg" {
+  name        = "cra-upd-docdb-egress-sg"
+  description = "Allow egress to DocumentDB"
+  vpc_id      = var.vpc_id
+}

--- a/terragrunt/aws/elasticache/elasticache.tf
+++ b/terragrunt/aws/elasticache/elasticache.tf
@@ -1,0 +1,35 @@
+resource "aws_elasticache_replication_group" "cra_upd_elasticache_replication_group" {
+  engine                     = "valkey"
+  engine_version             = "7.2"
+  port                       = 6379
+  replication_group_id       = "cra-upd-elasticache-rep-group"
+  description                = "UPD Elasticache Replication Group"
+  parameter_group_name       = aws_elasticache_parameter_group.cra_upd_elasticache_param_group.name
+  node_type                  = var.elasticache_node_type
+  num_cache_clusters         = 1
+  cluster_mode               = "disabled"
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = false
+  subnet_group_name          = aws_elasticache_subnet_group.cra_upd_elasticache_subnet_group.name
+  security_group_ids         = [aws_security_group.cra_upd_elasticache_sg.id]
+  apply_immediately          = true
+
+  lifecycle {
+    ignore_changes = [num_cache_clusters]
+  }
+}
+
+resource "aws_elasticache_subnet_group" "cra_upd_elasticache_subnet_group" {
+  name       = "cra-upd-elasticache-subnet-group"
+  subnet_ids = var.vpc_private_subnet_ids
+}
+
+resource "aws_elasticache_parameter_group" "cra_upd_elasticache_param_group" {
+  name   = "cra-upd-elasticache-param-group"
+  family = "valkey7"
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "noeviction"
+  }
+}

--- a/terragrunt/aws/elasticache/inputs.tf
+++ b/terragrunt/aws/elasticache/inputs.tf
@@ -1,0 +1,20 @@
+variable "vpc_id" {
+  description = "The VPC id of the CRA UPD app"
+  type        = string
+}
+
+variable "vpc_private_subnet_ids" {
+  description = "The private subnet ids of the VPC"
+  type        = list(any)
+}
+
+variable "vpc_cidr_block" {
+  description = "The cidr block of the VPC"
+  type        = string
+}
+
+variable "elasticache_node_type" {
+  description = "The instance type of the ElastiCache cluster"
+  type        = string
+  default     = "cache.t4g.micro"
+}

--- a/terragrunt/aws/elasticache/outputs.tf
+++ b/terragrunt/aws/elasticache/outputs.tf
@@ -1,6 +1,7 @@
 output "elasticache_endpoint" {
   description = "ElastiCache Endpoint for CRA UPD"
   value       = aws_elasticache_replication_group.cra_upd_elasticache_replication_group.primary_endpoint_address
+  sensitive   = true
 }
 
 output "elasticache_egress_sg_id" {

--- a/terragrunt/aws/elasticache/outputs.tf
+++ b/terragrunt/aws/elasticache/outputs.tf
@@ -1,0 +1,9 @@
+output "elasticache_endpoint" {
+  description = "ElastiCache Endpoint for CRA UPD"
+  value       = aws_elasticache_replication_group.cra_upd_elasticache_replication_group.primary_endpoint_address
+}
+
+output "elasticache_egress_sg_id" {
+  description = "ID of the security group to allow egress to ElastiCache"
+  value       = aws_security_group.cra_upd_elasticache_egress_sg.id
+}

--- a/terragrunt/aws/elasticache/security_groups.tf
+++ b/terragrunt/aws/elasticache/security_groups.tf
@@ -1,0 +1,26 @@
+resource "aws_security_group" "cra_upd_elasticache_sg" {
+  name        = "cra-upd-elasticache-sg"
+  description = "ElastiCache Security Group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow ingress from the VPC to ElastiCache"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr_block]
+  }
+}
+resource "aws_security_group" "cra_upd_elasticache_egress_sg" {
+  name        = "cra-upd-elasticache-egress-sg"
+  description = "Allow egress to ElastiCache"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description     = "Allow egress to ElastiCache"
+    from_port       = 6379
+    to_port         = 6379
+    protocol        = "tcp"
+    security_groups = [aws_security_group.cra_upd_elasticache_sg.id]
+  }
+}

--- a/terragrunt/env/staging/database/.terraform.lock.hcl
+++ b/terragrunt/env/staging/database/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.98.0"
+  constraints = "~> 5.39"
+  hashes = [
+    "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}

--- a/terragrunt/env/staging/database/terragrunt.hcl
+++ b/terragrunt/env/staging/database/terragrunt.hcl
@@ -1,0 +1,41 @@
+terraform {
+  source = "../../../aws//database"
+}
+
+dependencies {
+  paths = ["../network", "../ssm"]
+}
+
+dependency "network" {
+  config_path                             = "../network"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    vpc_id                 = ""
+    vpc_private_subnet_ids = [""]
+    vpc_cidr_block         = "10.0.0.0/16"
+  }
+}
+
+dependency "ssm" {
+  config_path                             = "../ssm"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    ssm_secret_arns = []
+  }
+}
+
+inputs = {
+  vpc_id                 = dependency.network.outputs.vpc_id
+  vpc_private_subnet_ids = dependency.network.outputs.vpc_private_subnet_ids
+  vpc_cidr_block         = dependency.network.outputs.vpc_cidr_block
+  docdb_instance_class   = "db.t4g.medium" # start with smallest instance class and scale up as needed
+  docdb_instance_count   = 1
+  docdb_storage_type     = "iopt1"
+  docdb_backup_window    = "02:00-04:00" # Daily time range that backups execute (UTC time)
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}

--- a/terragrunt/env/staging/elasticache/.terraform.lock.hcl
+++ b/terragrunt/env/staging/elasticache/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.98.0"
+  constraints = "~> 5.39"
+  hashes = [
+    "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}

--- a/terragrunt/env/staging/elasticache/terragrunt.hcl
+++ b/terragrunt/env/staging/elasticache/terragrunt.hcl
@@ -1,0 +1,29 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../aws//elasticache"
+}
+
+dependencies {
+  paths = ["../network"]
+}
+
+dependency "network" {
+  config_path                             = "../network"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    vpc_id                 = ""
+    vpc_private_subnet_ids = [""]
+    vpc_cidr_block         = "10.0.0.0/16"
+  }
+}
+
+inputs = {
+  vpc_id                 = dependency.network.outputs.vpc_id
+  vpc_private_subnet_ids = dependency.network.outputs.vpc_private_subnet_ids
+  vpc_cidr_block         = dependency.network.outputs.vpc_cidr_block
+  elasticache_node_type  = "cache.t4g.micro"
+}


### PR DESCRIPTION
# Summary | Résumé

This PR adds the Terraform for DocumentDB and Elasticache. (see individual commits if you want to look at them in isolation)

Note that they both have at-rest encryption enabled, but I couldn't get the in-transit encryption to work for Elasticache. I narrowed it down to some sort of configuration issue with the client we're using, but opted to focus on other priorities instead of spending more time there. Considering the strict security group and the fact that we won't be storing sensitive data, this should be fine for now.