### PR TITLE
Feat/terraform web

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -158,6 +158,6 @@ jobs:
         working-directory: terragrunt/env/staging/api_gateway
         run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
-      # - name: Apply web
-      #   working-directory: terragrunt/env/staging/web
-      #   run: terragrunt apply --terragrunt-non-interactive -auto-approve
+      - name: Apply web
+        working-directory: terragrunt/env/staging/web
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -88,7 +88,7 @@ jobs:
           - module: s3
           # - module: s3_web_files
           - module: ssm
-          # - module: web
+          - module: web
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/terragrunt/aws/web/acl.tf
+++ b/terragrunt/aws/web/acl.tf
@@ -1,0 +1,48 @@
+resource "aws_wafv2_ip_set" "cra_upd_waf_ip_set" {
+  name               = "cra-upd-waf-ip-set"
+  description        = "CRA UPD IP address allow list"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+  addresses          = var.cloudfront_waf_allowed_ips
+
+  provider = aws.us-east-1
+}
+
+resource "aws_wafv2_web_acl" "cra_upd_waf_acl" {
+  name        = "cra-upd-cloudfront-waf-acl"
+  description = "Block access from IPs not on the allowlist"
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = "AllowIpsFromAllowlist"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.cra_upd_waf_ip_set.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "cra-upd-waf-cloudfront-allow-ips"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "cra-upd-waf-cloudfront-block-traffic"
+    sampled_requests_enabled   = true
+  }
+
+  provider = aws.us-east-1
+}

--- a/terragrunt/aws/web/cloudfront.tf
+++ b/terragrunt/aws/web/cloudfront.tf
@@ -103,9 +103,3 @@ resource "aws_cloudfront_distribution" "cra_upd_cf_distribution" {
     minimum_protocol_version       = "TLSv1.2_2021"
   }
 }
-
-#! Outputs the cloudfront domain name for testing- remove this after
-output "cloudfront_distribution_domain_name" {
-  value       = aws_cloudfront_distribution.cra_upd_cf_distribution.domain_name
-  description = "Cloudfront distribution domain name"
-}

--- a/terragrunt/aws/web/cloudfront.tf
+++ b/terragrunt/aws/web/cloudfront.tf
@@ -1,0 +1,111 @@
+locals {
+  cloudfront_web_origin_id = "upd_web"
+  cloudfront_api_origin_id = "upd_api"
+}
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = "Cloudfront origin access identity"
+}
+
+data "aws_iam_policy_document" "cra_upd_web_bucket_policy_doc" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
+    }
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      "${var.web_bucket_arn}/*"
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "cra_upd_web_bucket_policy" {
+  bucket = var.web_bucket_id
+  policy = data.aws_iam_policy_document.cra_upd_web_bucket_policy_doc.json
+}
+
+resource "aws_cloudfront_distribution" "cra_upd_cf_distribution" {
+  enabled             = true
+  default_root_object = "index.html"
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_100"
+  web_acl_id          = aws_wafv2_web_acl.cra_upd_waf_acl.arn
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  origin {
+    domain_name = var.web_bucket_domain
+    origin_id   = local.cloudfront_web_origin_id
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  origin {
+    domain_name = var.apigw_endpoint_url
+    origin_id   = local.cloudfront_api_origin_id
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = local.cloudfront_api_origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    #* Will likely want to revisit caching for API calls
+    # CachingDisabled managed policy ID:
+    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+
+    # AllViewerExceptHostHeader managed policy ID:
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.cloudfront_web_origin_id
+    compress         = true
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 300
+    max_ttl                = 1200
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = aws_acm_certificate.cra_upd_cloudfront_acm.arn
+    minimum_protocol_version       = "TLSv1.2_2021"
+  }
+}
+
+#! Outputs the cloudfront domain name for testing- remove this after
+output "cloudfront_distribution_domain_name" {
+  value       = aws_cloudfront_distribution.cra_upd_cf_distribution.domain_name
+  description = "Cloudfront distribution domain name"
+}

--- a/terragrunt/aws/web/cloudfront.tf
+++ b/terragrunt/aws/web/cloudfront.tf
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "cra_upd_cf_distribution" {
   }
 
   origin {
-    domain_name = var.apigw_endpoint_url
+    domain_name = var.apigw_endpoint_domain
     origin_id   = local.cloudfront_api_origin_id
 
     custom_origin_config {
@@ -63,43 +63,102 @@ resource "aws_cloudfront_distribution" "cra_upd_cf_distribution" {
 
   ordered_cache_behavior {
     path_pattern           = "/api/*"
-    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST"]
+    allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
     cached_methods         = ["GET", "HEAD"]
     target_origin_id       = local.cloudfront_api_origin_id
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
 
-    #* Will likely want to revisit caching for API calls
-    # CachingDisabled managed policy ID:
-    cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+    cache_policy_id = aws_cloudfront_cache_policy.cra_upd_api_cache_policy.id
 
     # AllViewerExceptHostHeader managed policy ID:
     origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+
+    # Managed-CORS-With-Preflight
+    response_headers_policy_id = "5cc3b908-e619-4b99-88e5-2cf7f45965bd"
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.cloudfront_web_origin_id
     compress         = true
 
-    forwarded_values {
-      query_string = false
+    cache_policy_id = aws_cloudfront_cache_policy.cra_upd_s3_cache_policy.id
 
-      cookies {
-        forward = "none"
-      }
-    }
+    # CORS-S3Origin managed policy ID:
+    origin_request_policy_id = "88a5eaf4-2fd4-4709-b370-b4c650ea3fcf"
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 300
-    max_ttl                = 1200
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.cra_upd_cf_viewer_request_function.arn
+    }
   }
 
   viewer_certificate {
     cloudfront_default_certificate = false
     acm_certificate_arn            = aws_acm_certificate.cra_upd_cloudfront_acm.arn
+    ssl_support_method             = "sni-only"
     minimum_protocol_version       = "TLSv1.2_2021"
   }
+}
+
+resource "aws_cloudfront_cache_policy" "cra_upd_s3_cache_policy" {
+  name        = "cra_upd_s3_cache_policy"
+  comment     = "The cache policy for the S3 web bucket origin"
+  min_ttl     = 1
+  default_ttl = 300
+  max_ttl     = 1200
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = true
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "cra_upd_api_cache_policy" {
+  name        = "cra_upd_api_cache_policy"
+  comment     = "The cache policy for the API Gateway origin"
+  min_ttl     = 1
+  default_ttl = 120
+  max_ttl     = 31536000
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+
+    enable_accept_encoding_gzip   = true
+    enable_accept_encoding_brotli = false
+  }
+}
+
+resource "aws_cloudfront_function" "cra_upd_cf_viewer_request_function" {
+  name    = "url-rewrite-function"
+  runtime = "cloudfront-js-2.0"
+  comment = "Rewrites URLs to enable SPA routing"
+  publish = true
+  code    = file("${path.module}/url-rewriter.js")
 }

--- a/terragrunt/aws/web/dns.tf
+++ b/terragrunt/aws/web/dns.tf
@@ -1,0 +1,58 @@
+resource "aws_route53_zone" "cra_upd_hosted_zone" {
+  name = var.domain
+  
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "cra_upd_cloudfront_alias" {
+  zone_id = aws_route53_zone.cra_upd_hosted_zone.zone_id
+  name    = var.domain
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.cra_upd_cf_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.cra_upd_cf_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+  
+  provider = aws.dns
+}
+
+resource "aws_acm_certificate" "cra_upd_cloudfront_acm" {
+  domain_name               = var.domain
+  subject_alternative_names = ["*.${var.domain}"]
+  validation_method         = "DNS"
+
+  provider = aws.us-east-1
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cra_upd_cert_validation_record" {
+  zone_id = aws_route53_zone.cra_upd_hosted_zone.zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.cra_upd_cloudfront_acm.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+  ttl             = 60
+
+  provider = aws.dns
+}
+
+resource "aws_acm_certificate_validation" "cra_upd_cert_validation" {
+  certificate_arn         = aws_acm_certificate.cra_upd_cloudfront_acm.arn
+  validation_record_fqdns = [for record in aws_route53_record.cra_upd_cert_validation_record : record.fqdn]
+
+  provider = aws.us-east-1
+}

--- a/terragrunt/aws/web/dns.tf
+++ b/terragrunt/aws/web/dns.tf
@@ -1,7 +1,5 @@
 resource "aws_route53_zone" "cra_upd_hosted_zone" {
   name = var.domain
-  
-  provider = aws.dns
 }
 
 resource "aws_route53_record" "cra_upd_cloudfront_alias" {
@@ -14,8 +12,6 @@ resource "aws_route53_record" "cra_upd_cloudfront_alias" {
     zone_id                = aws_cloudfront_distribution.cra_upd_cf_distribution.hosted_zone_id
     evaluate_target_health = false
   }
-  
-  provider = aws.dns
 }
 
 resource "aws_acm_certificate" "cra_upd_cloudfront_acm" {
@@ -46,8 +42,6 @@ resource "aws_route53_record" "cra_upd_cert_validation_record" {
   records         = [each.value.record]
   type            = each.value.type
   ttl             = 60
-
-  provider = aws.dns
 }
 
 resource "aws_acm_certificate_validation" "cra_upd_cert_validation" {

--- a/terragrunt/aws/web/inputs.tf
+++ b/terragrunt/aws/web/inputs.tf
@@ -1,5 +1,5 @@
-variable "apigw_endpoint_url" {
-  description = "API Gateway Endpoint URL for the CRA UPD app"
+variable "apigw_endpoint_domain" {
+  description = "API Gateway Endpoint Domain for the CRA UPD app"
   type        = string
 
   sensitive = true

--- a/terragrunt/aws/web/inputs.tf
+++ b/terragrunt/aws/web/inputs.tf
@@ -1,0 +1,24 @@
+variable "apigw_endpoint_url" {
+  description = "API Gateway Endpoint URL for the CRA UPD app"
+  type        = string
+}
+
+variable "cloudfront_waf_allowed_ips" {
+  description = "List of IP addresses to allow through the CloudFront WAF"
+  type        = list(string)
+}
+
+variable "web_bucket_id" {
+  description = "The ID of the web resources S3 bucket."
+  type        = string
+}
+
+variable "web_bucket_arn" {
+  description = "The ARN of the web resources S3 bucket."
+  type        = string
+}
+
+variable "web_bucket_domain" {
+  description = "The domain name of the web resources S3 bucket."
+  type        = string
+}

--- a/terragrunt/aws/web/inputs.tf
+++ b/terragrunt/aws/web/inputs.tf
@@ -1,11 +1,15 @@
 variable "apigw_endpoint_url" {
   description = "API Gateway Endpoint URL for the CRA UPD app"
   type        = string
+
+  sensitive = true
 }
 
 variable "cloudfront_waf_allowed_ips" {
   description = "List of IP addresses to allow through the CloudFront WAF"
   type        = list(string)
+
+  sensitive = true
 }
 
 variable "web_bucket_id" {
@@ -21,4 +25,6 @@ variable "web_bucket_arn" {
 variable "web_bucket_domain" {
   description = "The domain name of the web resources S3 bucket."
   type        = string
+
+  sensitive = true
 }

--- a/terragrunt/aws/web/outputs.tf
+++ b/terragrunt/aws/web/outputs.tf
@@ -1,0 +1,4 @@
+output "distribution_id" {
+  description = "The ID of the CloudFront distribution"
+  value       = aws_cloudfront_distribution.cra_upd_cf_distribution.id
+}

--- a/terragrunt/aws/web/url-rewriter.js
+++ b/terragrunt/aws/web/url-rewriter.js
@@ -1,0 +1,15 @@
+/*
+ * Cloudfront function to rewrite URLs for SPA routing.
+ */
+
+var fileRegex = /^\/.+(\.\w+$)/; // matches paths requesting a file. e.g.: /route1/my-font.woff2
+
+function handler(event) {
+  var request = event.request;
+
+  if (!fileRegex.test(request.uri)) {
+    request.uri = '/index.html';
+  }
+
+  return request;
+}

--- a/terragrunt/env/staging/web/.terraform.lock.hcl
+++ b/terragrunt/env/staging/web/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.98.0"
+  constraints = "~> 5.39"
+  hashes = [
+    "h1:KgOCdSG6euSc2lquuFlISJU/CzQTRhAO7WoaASxLZRc=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}

--- a/terragrunt/env/staging/web/terragrunt.hcl
+++ b/terragrunt/env/staging/web/terragrunt.hcl
@@ -12,16 +12,16 @@ dependencies {
 
 dependency "api_gateway" {
   config_path                             = "../api_gateway"
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
-    cra_upd_apigw_endpoint_url = ""
+    apigw_endpoint_domain = ""
   }
 }
 
 dependency "s3" {
   config_path                             = "../s3"
-  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show", "destroy"]
   mock_outputs_merge_with_state           = true
   mock_outputs = {
     web_bucket_id     = ""
@@ -31,7 +31,7 @@ dependency "s3" {
 }
 
 inputs = {
-  apigw_endpoint_url         = dependency.api_gateway.outputs.cra_upd_apigw_endpoint_url
+  apigw_endpoint_domain      = dependency.api_gateway.outputs.apigw_endpoint_domain
   cloudfront_waf_allowed_ips = split(",", get_env("CLOUDFRONT_WAF_ALLOWED_IPS"))
   web_bucket_id              = dependency.s3.outputs.web_bucket_id
   web_bucket_arn             = dependency.s3.outputs.web_bucket_arn

--- a/terragrunt/env/staging/web/terragrunt.hcl
+++ b/terragrunt/env/staging/web/terragrunt.hcl
@@ -1,0 +1,39 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source = "../../../aws//web"
+}
+
+dependencies {
+  paths = ["../api_gateway", "../s3"]
+}
+
+dependency "api_gateway" {
+  config_path                             = "../api_gateway"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    cra_upd_apigw_endpoint_url = ""
+  }
+}
+
+dependency "s3" {
+  config_path                             = "../s3"
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_with_state           = true
+  mock_outputs = {
+    web_bucket_id     = ""
+    web_bucket_arn    = ""
+    web_bucket_domain = ""
+  }
+}
+
+inputs = {
+  apigw_endpoint_url         = dependency.api_gateway.outputs.cra_upd_apigw_endpoint_url
+  cloudfront_waf_allowed_ips = split(",", get_env("CLOUDFRONT_WAF_ALLOWED_IPS"))
+  web_bucket_id              = dependency.s3.outputs.web_bucket_id
+  web_bucket_arn             = dependency.s3.outputs.web_bucket_arn
+  web_bucket_domain          = dependency.s3.outputs.web_bucket_domain
+}


### PR DESCRIPTION
This PR adds the Terraform for the Web module (CloudFront + Route53).

I honestly wasn't too sure what I was doing with the Route53 stuff, I mostly just tried to follow what's in CDS' `simple-static-website` module [here](https://github.com/cds-snc/terraform-modules/blob/main/simple_static_website/route53.tf) and [here](https://github.com/cds-snc/terraform-modules/blob/main/simple_static_website/acm.tf). Hopefully I did it right!