### PR TITLE
fix: Add permissions for GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_and_upload_web_files_staging.yml
+++ b/.github/workflows/build_and_upload_web_files_staging.yml
@@ -21,6 +21,14 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  actions: write
+  checks: write
+  statuses: write
+
 jobs:
   build:
     name: Nx Cloud - Build web - Main Job


### PR DESCRIPTION
# Summary | Résumé
Adds missing permissions to the Github Actions workflow that builds and uploads web resources to S3.