### PR TITLE
feat: add avg_time_spent metric

### DIFF
--- a/apps/api/src/pages/pages.controller.ts
+++ b/apps/api/src/pages/pages.controller.ts
@@ -48,4 +48,9 @@ export class PagesController {
   async runAccessibilityTest(@Query('url') url: string) {
     return this.pagesService.runAccessibilityTest(url);
   }
+
+  @Get('getPageId')
+  getPageId(@Query('url') url: string) {
+    return this.pagesService.getPageId(url);
+  }
 }

--- a/apps/api/src/pages/pages.service.ts
+++ b/apps/api/src/pages/pages.service.ts
@@ -339,7 +339,7 @@ export class PagesService {
           visits: data.visits,
         })),
         dyfByDay: await this.getDyfByDay(params.comparisonDateRange, params.id),
-        average_time_spent: averageTimeSpent.comparison
+        average_time_spent: averageTimeSpent.comparison,
       },
       topSearchTermsIncrease: topIncreasedSearchTerms,
       topSearchTermsDecrease: topDecreasedSearchTerms,
@@ -584,6 +584,14 @@ export class PagesService {
         clicksChange,
       };
     });
+  }
+
+  async getPageId(url: string) {
+    const pageId = await this.db.collections.pages
+      .findOne({ url }, { _id: 1 })
+      .lean()
+      .exec();
+      return { id: pageId?._id.toString() || null };
   }
 
   async runAccessibilityTest(url: string) {

--- a/apps/api/src/pages/pages.service.ts
+++ b/apps/api/src/pages/pages.service.ts
@@ -197,7 +197,7 @@ export class PagesService {
       'visits_device_desktop',
       'visits_device_mobile',
       'visits_device_tablet',
-      { $avg: 'average_time_spent' },
+      'average_time_spent',
       'gsc_total_clicks',
       'gsc_total_impressions',
       { $avg: 'gsc_total_ctr' },
@@ -307,6 +307,7 @@ export class PagesService {
       topIncreasedSearchTerms,
       topDecreasedSearchTerms,
       activityMap,
+      averageTimeSpent,
     } = await this.db.views.pages.getPageDetailsData(
       page._id,
       dateRange,
@@ -328,6 +329,7 @@ export class PagesService {
           visits: data.visits,
         })),
         dyfByDay: await this.getDyfByDay(params.dateRange, params.id),
+        average_time_spent: averageTimeSpent.current,
       },
       comparisonDateRange: params.comparisonDateRange,
       comparisonDateRangeData: {
@@ -337,6 +339,7 @@ export class PagesService {
           visits: data.visits,
         })),
         dyfByDay: await this.getDyfByDay(params.comparisonDateRange, params.id),
+        average_time_spent: averageTimeSpent.comparison
       },
       topSearchTermsIncrease: topIncreasedSearchTerms,
       topSearchTermsDecrease: topDecreasedSearchTerms,

--- a/libs/db/src/lib/views/pages.view.ts
+++ b/libs/db/src/lib/views/pages.view.ts
@@ -26,6 +26,7 @@ import {
   arrayToDictionary,
   getArraySelectedPercentChange,
   isNullish,
+  percentChange,
   prettyJson,
 } from '@dua-upd/utils-common';
 
@@ -461,6 +462,7 @@ export class PagesViewService extends DbViewNew<
           | 'aa_searchterms'
           | 'gsc_searchterms'
           | 'activity_map'
+          | 'average_time_spent'
         >
       >(
         {
@@ -473,6 +475,7 @@ export class PagesViewService extends DbViewNew<
           aa_searchterms: 1,
           gsc_searchterms: 1,
           activity_map: 1,
+          average_time_spent: 1,
         },
       );
 
@@ -539,12 +542,18 @@ export class PagesViewService extends DbViewNew<
         ).sort((a, b) => b.clicks - a.clicks)
       : [];
 
+    const averageTimeSpent = {
+      current: currentData?.average_time_spent || 0,
+      comparison: comparisonData?.average_time_spent || 0,
+    };
+
     return {
       aaSearchTerms,
       top25GSCSearchTerms,
       topIncreasedSearchTerms,
       topDecreasedSearchTerms,
       activityMap,
+      averageTimeSpent,
     };
   }
 }

--- a/libs/upd/components/src/lib/data-card/data-card.component.ts
+++ b/libs/upd/components/src/lib/data-card/data-card.component.ts
@@ -3,6 +3,7 @@ import {
   LocaleNumberPipe,
   LocalePercentPipe,
   LocaleTemplatePipe,
+  SecondsToMinutesPipe,
 } from '@dua-upd/upd/pipes';
 
 export type ComparisonStatus = 'good' | 'bad' | 'neutral' | 'none';
@@ -115,6 +116,7 @@ export class DataCardComponent {
   private numberPipe: LocaleNumberPipe = inject(LocaleNumberPipe);
   private percentPipe: LocalePercentPipe = inject(LocalePercentPipe);
   private templatePipe: LocaleTemplatePipe = inject(LocaleTemplatePipe);
+  private secondsToMinutesPipe: SecondsToMinutesPipe = inject(SecondsToMinutesPipe);
 
   @Input() current: number | null = null;
   @Input() comparison?: number | null;
@@ -123,7 +125,7 @@ export class DataCardComponent {
   @Input() tooltip = '';
   @Input() modalTitle = '';
   @Input() modal = '';
-  @Input() pipe: 'percent' | 'number' | 'template' = 'number';
+  @Input() pipe: 'percent' | 'number' | 'template' | 'secondToMinutes' = 'number';
   @Input() pipeParams?: string | string[];
   @Input() emptyMessage = 'nodata-available';
 
@@ -207,6 +209,8 @@ export class DataCardComponent {
         return this.percentPipe;
       case 'template':
         return this.templatePipe;
+      case 'secondToMinutes':
+        return this.secondsToMinutesPipe;
       default:
         return this.numberPipe;
     }

--- a/libs/upd/pipes/src/lib/pipes.module.ts
+++ b/libs/upd/pipes/src/lib/pipes.module.ts
@@ -28,7 +28,6 @@ export class LocaleNumberPipe implements PipeTransform {
 })
 export class LocaleDatePipe implements PipeTransform {
   private i18n = inject(I18nService);
-  private _ref = inject(ChangeDetectorRef, { host: true });
 
   transform(
     value?: string | Date | null,
@@ -137,11 +136,16 @@ export class TruncatePipe implements PipeTransform {
     standalone: false
 })
 export class SecondsToMinutesPipe implements PipeTransform {
-  transform(value: number): string {
-    value = Math.round(value);
-    const minutes = Math.floor(value / 60);
-    const seconds = value - minutes * 60;
-    return `${minutes}m ${seconds}s`;
+  transform(value?: number | null): string | number | null | undefined {
+    return typeof value === 'number'
+      ? (() => {
+          const total = Math.round(value);
+          const minutes = Math.floor(total / 60);
+          const seconds = total % 60;
+
+          return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+        })()
+      : value;
   }
 }
 

--- a/libs/upd/views/pages/src/lib/pages-details/+state/pages-details.facade.ts
+++ b/libs/upd/views/pages/src/lib/pages-details/+state/pages-details.facade.ts
@@ -165,6 +165,13 @@ export class PagesDetailsFacade {
   pageViewsPercentChange$ = this.pagesDetailsData$.pipe(
     mapToPercentChange('views'),
   );
+  
+  averageTimeSpent$ = this.pagesDetailsData$.pipe(
+    map((data) => data?.dateRangeData?.average_time_spent || 0),
+  );
+  averageTimeSpentPercentChange$ = this.pagesDetailsData$.pipe(
+    mapToPercentChange('average_time_spent'),
+  );
 
   impressions$ = this.pagesDetailsData$.pipe(
     map((data) => data?.dateRangeData?.gsc_total_impressions || 0),

--- a/libs/upd/views/pages/src/lib/pages-details/pages-details-summary/pages-details-summary.component.ts
+++ b/libs/upd/views/pages/src/lib/pages-details/pages-details-summary/pages-details-summary.component.ts
@@ -52,6 +52,9 @@ export class PagesDetailsSummaryComponent implements OnInit {
   visitsByDay$ = this.pageDetailsService.visitsByDay$;
 
   visitsByDeviceType$ = this.pageDetailsService.visitsByDeviceType$;
+  
+  averageTimeSpent$ = this.pageDetailsService.averageTimeSpent$;
+  averageTimeSpentPercentChange$ = this.pageDetailsService.averageTimeSpentPercentChange$;
 
   topSearchTermsIncrease$ = this.pageDetailsService.topSearchTermsIncrease$;
 

--- a/libs/upd/views/pages/src/lib/pages-routing.module.ts
+++ b/libs/upd/views/pages/src/lib/pages-routing.module.ts
@@ -12,31 +12,69 @@ import { PagesDetailsFlowComponent } from './pages-details/pages-details-flow/pa
 import { PagesDetailsReadabilityComponent } from './pages-details/pages-details-readability/pages-details-readability.component';
 import { PagesDetailsVersionsComponent } from './pages-details/pages-details-versions/pages-details-versions.component';
 import { PagesDetailsAccessibilityComponent } from './pages-details/pages-details-accessibility/pages-details-accessibility.component';
+import { pagesUrlRedirectGuard } from './pages-url-redirect.guard';
 
 const routes: Routes = [
   {
     path: '',
     component: PagesComponent,
     children: [
-      { path: '', component: PagesHomeComponent, pathMatch: 'full' },
+      {
+        path: '',
+        component: PagesHomeComponent,
+        pathMatch: 'full',
+        canActivate: [pagesUrlRedirectGuard],
+      },
       {
         path: ':id',
         component: PagesDetailsComponent,
         children: [
           { path: '', redirectTo: 'summary', pathMatch: 'full' },
-          { path: 'summary', component: PagesDetailsSummaryComponent, data: {title: 'Pages | Summary'} },
-          { path: 'webtraffic', component: PagesDetailsWebtrafficComponent, data: {title: 'Pages | Web traffic'} },
-          { path: 'searchanalytics', component: PagesDetailsSearchAnalyticsComponent, data: {title: 'Pages | Search analytics'} },
-          { path: 'pagefeedback', component: PagesDetailsFeedbackComponent, data: {title: 'Pages | Page feedback'} },
-          { path: 'flow', component: PagesDetailsFlowComponent, data: {title: 'Pages | Flow'} },
-          { path: 'readability', component: PagesDetailsReadabilityComponent, data: {title: 'Pages | Readability'} },
-          { path: 'version-history', component: PagesDetailsVersionsComponent, data: {title: 'Pages | Version history'} },
-          { path: 'accessibility', component: PagesDetailsAccessibilityComponent, data: {title: 'Pages | Accessibility'} },
+          {
+            path: 'summary',
+            component: PagesDetailsSummaryComponent,
+            data: { title: 'Pages | Summary' },
+          },
+          {
+            path: 'webtraffic',
+            component: PagesDetailsWebtrafficComponent,
+            data: { title: 'Pages | Web traffic' },
+          },
+          {
+            path: 'searchanalytics',
+            component: PagesDetailsSearchAnalyticsComponent,
+            data: { title: 'Pages | Search analytics' },
+          },
+          {
+            path: 'pagefeedback',
+            component: PagesDetailsFeedbackComponent,
+            data: { title: 'Pages | Page feedback' },
+          },
+          {
+            path: 'flow',
+            component: PagesDetailsFlowComponent,
+            data: { title: 'Pages | Flow' },
+          },
+          {
+            path: 'readability',
+            component: PagesDetailsReadabilityComponent,
+            data: { title: 'Pages | Readability' },
+          },
+          {
+            path: 'version-history',
+            component: PagesDetailsVersionsComponent,
+            data: { title: 'Pages | Version history' },
+          },
+          {
+            path: 'accessibility',
+            component: PagesDetailsAccessibilityComponent,
+            data: { title: 'Pages | Accessibility' },
+          },
         ],
       },
     ],
   },
-]
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/libs/upd/views/pages/src/lib/pages-url-redirect.guard.ts
+++ b/libs/upd/views/pages/src/lib/pages-url-redirect.guard.ts
@@ -1,0 +1,44 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { catchError, map, of } from 'rxjs';
+
+import { I18nFacade } from '@dua-upd/upd/state';
+import { EN_CA, FR_CA } from '@dua-upd/upd/i18n';
+
+const sanitizeUrl = (url: string) =>
+  url.trim().replace(/^https?:\/\//, '')
+
+const toLang = (lang: string | null) =>
+  lang?.toLowerCase().startsWith('fr') ? 'fr' : 'en';
+
+export const pagesUrlRedirectGuard: CanActivateFn = (route) => {
+  const router = inject(Router);
+  const http = inject(HttpClient);
+  const i18n = inject(I18nFacade);
+
+  const rawUrl = route.queryParamMap.get('url');
+  if (!rawUrl) return true;
+
+  const lang = toLang(route.queryParamMap.get('lang'));
+  i18n.setLang(lang === 'fr' ? FR_CA : EN_CA);
+
+  return http
+    .get<{
+      id: string | null;
+    }>('/api/pages/getPageId', { params: { url: sanitizeUrl(rawUrl) } })
+    .pipe(
+      map(({ id }) =>
+        router.createUrlTree(
+          id ? ['/', lang, 'pages', id, 'summary'] : ['/', lang, 'pages'],
+        ),
+      ),
+      catchError(() =>
+        of(
+          router.createUrlTree(['/', lang, 'pages'], {
+            queryParams: { error: 1 },
+          }),
+        ),
+      ),
+    );
+};

--- a/python/mongo-parquet/src/mongo_parquet/views/metrics_common.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/metrics_common.py
@@ -49,6 +49,7 @@ metrics_common_schema = {
     "visits_referrer_social": int32(),
     "visits_referrer_typed_bookmarked": int32(),
     "visits_referrer_convo_ai": int32(),
+    "average_time_spent": float64(),
 }
 
 metrics_common_top_level_aggregations_expr = [
@@ -88,4 +89,7 @@ metrics_common_top_level_aggregations_expr = [
     pl.col("visits_device_desktop").sum(),
     pl.col("visits_device_mobile").sum(),
     pl.col("visits_device_tablet").sum(),
+    (
+        (pl.col("visits") * pl.col("average_time_spent")).sum() / pl.col("visits").sum()
+    ).alias("average_time_spent"),
 ]

--- a/python/mongo-parquet/src/mongo_parquet/views/metrics_common.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/metrics_common.py
@@ -2,7 +2,6 @@ import polars as pl
 from pyarrow import string, struct, list_, float64, int32
 
 metrics_common_schema = {
-    "average_time_spent": float64(),
     "bouncerate": float64(),
     "dyf_no": int32(),
     "dyf_submit": int32(),
@@ -53,7 +52,6 @@ metrics_common_schema = {
 }
 
 metrics_common_top_level_aggregations_expr = [
-    pl.col("average_time_spent").mean().round_sig_figs(5),
     pl.col("bouncerate").mean().round_sig_figs(5),
     pl.col("dyf_no").sum(),
     pl.col("dyf_yes").sum(),

--- a/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
@@ -49,7 +49,6 @@ class PagesView(ParquetModel):
             **metrics_common_schema,
             "pageStatus": string(),
             "numComments": int32(),
-            "average_time_spent": float64(),
             "aa_searchterms": list_(
                 struct(
                     {
@@ -293,14 +292,12 @@ class PagesViewService:
 
         top_level_metrics = self.get_top_level_page_metrics(date_range)
         num_comments = self.get_num_comments(date_range)
-        avg_time_spent = self.get_avg_time_spent(date_range)
         aa_searchterms = self.get_aa_searchterms(date_range)
         gsc_searchterms = self.get_gsc_searchterms(date_range)
         activity_map = self.get_activity_map(date_range)
         return (
             pages.join(top_level_metrics, on="url", how="left")
             .join(num_comments, on="url", how="left")
-            .join(avg_time_spent, on="url", how="left")
             .join(aa_searchterms, on="url", how="left")
             .join(gsc_searchterms, on="url", how="left")
             .join(activity_map, on="url", how="left")
@@ -384,22 +381,4 @@ class PagesViewService:
             .agg(pl.col("clicks").sum())
             .group_by(["url"])
             .agg(pl.struct(pl.all().top_k_by("clicks", 100)).alias("activity_map"))
-        )
-
-    def get_avg_time_spent(self, date_range: DateRange) -> pl.LazyFrame:
-        return (
-            self.dependencies["page_metrics"]
-            .lf()
-            .filter(
-                pl.col("date").is_between(date_range["start"], date_range["end"])
-            )
-            .with_columns(pl.col("url").cast(self.context.page_urls_enum))
-            .group_by("url")
-            .agg(
-                (
-                    (pl.col("visits") * pl.col("average_time_spent")).sum()
-                    / pl.col("visits").sum()
-                ).alias("average_time_spent")
-            )
-            .with_columns(pl.col("average_time_spent").cast(pl.Float64))
         )

--- a/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
@@ -49,7 +49,7 @@ class PagesView(ParquetModel):
             **metrics_common_schema,
             "pageStatus": string(),
             "numComments": int32(),
-            "avg_time_spent": float64(),
+            "average_time_spent": float64(),
             "aa_searchterms": list_(
                 struct(
                     {
@@ -399,7 +399,7 @@ class PagesViewService:
                 (
                     (pl.col("visits") * pl.col("average_time_spent")).sum()
                     / pl.col("visits").sum()
-                ).alias("avg_time_spent")
+                ).alias("average_time_spent")
             )
-            .with_columns(pl.col("avg_time_spent").cast(pl.Float64))
+            .with_columns(pl.col("average_time_spent").cast(pl.Float64))
         )

--- a/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
@@ -49,6 +49,7 @@ class PagesView(ParquetModel):
             **metrics_common_schema,
             "pageStatus": string(),
             "numComments": int32(),
+            "avg_time_spent": float64(),
             "aa_searchterms": list_(
                 struct(
                     {
@@ -292,12 +293,14 @@ class PagesViewService:
 
         top_level_metrics = self.get_top_level_page_metrics(date_range)
         num_comments = self.get_num_comments(date_range)
+        avg_time_spent = self.get_avg_time_spent(date_range)
         aa_searchterms = self.get_aa_searchterms(date_range)
         gsc_searchterms = self.get_gsc_searchterms(date_range)
         activity_map = self.get_activity_map(date_range)
         return (
             pages.join(top_level_metrics, on="url", how="left")
             .join(num_comments, on="url", how="left")
+            .join(avg_time_spent, on="url", how="left")
             .join(aa_searchterms, on="url", how="left")
             .join(gsc_searchterms, on="url", how="left")
             .join(activity_map, on="url", how="left")
@@ -381,4 +384,22 @@ class PagesViewService:
             .agg(pl.col("clicks").sum())
             .group_by(["url"])
             .agg(pl.struct(pl.all().top_k_by("clicks", 100)).alias("activity_map"))
+        )
+
+    def get_avg_time_spent(self, date_range: DateRange) -> pl.LazyFrame:
+        return (
+            self.dependencies["page_metrics"]
+            .lf()
+            .filter(
+                pl.col("date").is_between(date_range["start"], date_range["end"])
+            )
+            .with_columns(pl.col("url").cast(self.context.page_urls_enum))
+            .group_by("url")
+            .agg(
+                (
+                    (pl.col("visits") * pl.col("average_time_spent")).sum()
+                    / pl.col("visits").sum()
+                ).alias("avg_time_spent")
+            )
+            .with_columns(pl.col("avg_time_spent").cast(pl.Float64))
         )

--- a/scripts/shell/aws-sso-init.sh
+++ b/scripts/shell/aws-sso-init.sh
@@ -122,10 +122,10 @@ role_status=$?
 if [[ $role_status -ne 0 ]]; then
   echo "[aws-sso-init] Failed to determine a valid role"
   exit 1
-elif [[ $role_type -eq "admin" ]]; then
+elif [[ $role_type == "admin" ]]; then
   echo "[aws-sso-init] Already authenticated, skipping login"
   already_logged_in=true
-elif [[ $role_type -eq "user" ]]; then
+elif [[ $role_type == "user" ]]; then
   echo "[aws-sso-init] Starting SSO login..."
   aws sso login --no-browser || { echo "[aws-sso-init] SSO login failed. Retry with: aws sso login --no-browser" && exit 1; }
   already_logged_in=false


### PR DESCRIPTION
Adds average time spent per page (avg_time_spent) to the Pages view by computing a visits-weighted average over the date ranges