### PR TITLE
Fix/gsc incremental sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ CLAUDE.md
 # Zone.Identifier files (Windows WSL)
 *:Zone.Identifier
 .omx/
+.codex/

--- a/python/mongo-parquet/src/mongo_parquet/storage.py
+++ b/python/mongo-parquet/src/mongo_parquet/storage.py
@@ -110,6 +110,7 @@ class StorageClient:
         sample: bool = False,
         cleanup_local: bool = False,
         filepaths: list[str] | None = None,
+        dry_run: bool = False,
     ):
         """
         Upload Parquet files to remote storage.
@@ -117,6 +118,7 @@ class StorageClient:
         :param sample: Whether to upload sample files.
         :param cleanup_local: Whether to delete local files after upload.
         :param filepaths: List of specific file paths to upload, relative to the src directory.
+        :param dry_run: Whether to perform a dry run without actual upload.
         """
         local_dir_path = self.target_dirpath(sample=sample, remote=False)
 
@@ -128,7 +130,7 @@ class StorageClient:
             raise FileNotFoundError(f"Local directory {local_dir_path} does not exist.")
 
         filepath_tuples = (
-            [(local_dir_path, None, fp) for fp in filepaths]
+            [(local_dir_path, None, [fp for fp in filepaths])]
             if filepaths is not None
             else os.walk(local_dir_path)
         )
@@ -137,11 +139,15 @@ class StorageClient:
             print(f"⚠️ No files found in {local_dir_path} to upload.")
             return
 
+        if dry_run:
+            print(" ⚠️ Dry run enabled - no files will actually be uploaded.")
+
         for root, _, files in filepath_tuples:
             for file in files:
                 if file.endswith(".parquet"):
-                    # may need a different root if using explicit filepaths?
-                    local_path = os.path.join(root, file)
+                    local_path = (
+                        file if filepaths is not None else os.path.join(root, file)
+                    )
 
                     remote_filepath = local_path.replace(f"{local_dir_path}/", "")
 
@@ -150,6 +156,9 @@ class StorageClient:
                     )
 
                     print(f"⬆️  Uploading: {local_path} → {remote_path}")
+
+                    if dry_run:
+                        continue
 
                     with open(local_path, "rb") as f:
                         self.remote_fs.pipe_file(remote_path, f.read())

--- a/python/mongo-parquet/src/mongo_parquet/views/utils.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/utils.py
@@ -1,7 +1,8 @@
 import os
 import polars as pl
 import re
-from datetime import timedelta
+from datetime import datetime, timedelta
+from .daterange_utils import DateRange
 
 
 class ViewsUtils:
@@ -9,6 +10,8 @@ class ViewsUtils:
         temp_dir_str = os.path.join(parquet_dir_path, "..", temp_dir_name)
         self.parquet_dir_path: str = os.path.abspath(parquet_dir_path)
         self.temp_dir_path: str = os.path.abspath(temp_dir_str)
+        self._already_calculated_views: set[tuple[datetime, datetime]] = set()
+        self._already_inserted_views: set[tuple[datetime, datetime]] = set()
 
     def ensure_temp_dir(self):
         if not os.path.exists(self.temp_dir_path):
@@ -35,6 +38,24 @@ class ViewsUtils:
         self.ensure_temp_dir()
         temp_file_path = os.path.join(self.temp_dir_path, file_name)
         lf.sink_parquet(temp_file_path, compression_level=5, engine="streaming")
+
+    def set_view_calculated(self, date_range: DateRange):
+        self._already_calculated_views.add((date_range["start"], date_range["end"]))
+
+    def is_view_calculated(self, date_range: DateRange) -> bool:
+        return (date_range["start"], date_range["end"]) in self._already_calculated_views
+
+    def clear_already_calculated_views(self):
+        self._already_calculated_views.clear()
+
+    def set_view_inserted(self, date_range: DateRange):
+        self._already_inserted_views.add((date_range["start"], date_range["end"]))
+
+    def is_view_inserted(self, date_range: DateRange) -> bool:
+        return (date_range["start"], date_range["end"]) in self._already_inserted_views
+
+    def clear_already_inserted_views(self):
+        self._already_inserted_views.clear()
 
 
 def format_timedelta(td: timedelta) -> str:

--- a/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/view_pages.py
@@ -227,28 +227,43 @@ class PagesViewService:
         for dr in self.date_ranges_with_comparisons.values():  # pyright: ignore[reportAssignmentType]
             dr: DateRangeWithComparison = dr
             for date_range in [dr["date_range"], dr["comparison_date_range"]]:
+                if self.views_utils.is_view_calculated(date_range):
+                    print(
+                        f"Skipping calculation for {date_range['start'].date()} to {date_range['end'].date()} as it was already calculated."
+                    )
+                    continue
+
                 lf = self.get_view_date_range_data(date_range)
 
                 date_range_start_time = datetime.now()
                 print(
-                    f"Writing pages view for {date_range['start']} to {date_range['end']}..."
+                    f"Writing pages view for {date_range['start'].date()} to {date_range['end'].date()}..."
                 )
 
                 output_filename = f"view_pages_{date_range['start'].date()}_{date_range['end'].date()}.parquet"
 
                 self.views_utils.sink_temp(lf, output_filename)
+                self.views_utils.set_view_calculated(date_range)
 
                 print(
                     f"  Finished in {format_timedelta(datetime.now() - date_range_start_time)}"
                 )
 
+        self.views_utils.clear_already_calculated_views()
+
     def insert_pages_view_from_temp(self):
         for dr in self.date_ranges_with_comparisons.values():  # pyright: ignore[reportAssignmentType]
             dr: DateRangeWithComparison = dr
             for date_range in [dr["date_range"], dr["comparison_date_range"]]:
+                if self.views_utils.is_view_inserted(date_range):
+                    print(
+                        f"Skipping insertion for {date_range['start'].date()} to {date_range['end'].date()} as it was already inserted."
+                    )
+                    continue
+
                 date_range_start_time = datetime.now()
                 print(
-                    f"Inserting pages view for {date_range['start']} to {date_range['end']}..."
+                    f"Inserting pages view for {date_range['start'].date()} to {date_range['end'].date()}..."
                 )
 
                 filename = f"view_pages_{date_range['start'].date()}_{date_range['end'].date()}.parquet"
@@ -257,9 +272,13 @@ class PagesViewService:
                     self.insert_batch, chunk_size=20_000, lazy=False
                 )
 
+                self.views_utils.set_view_inserted(date_range)
+
                 print(
                     f"  Finished in {format_timedelta(datetime.now() - date_range_start_time)}"
                 )
+
+        self.views_utils.clear_already_inserted_views()
 
     def get_view_date_range_data(
         self,

--- a/python/mongo-parquet/src/mongo_parquet/views/view_tasks.py
+++ b/python/mongo-parquet/src/mongo_parquet/views/view_tasks.py
@@ -447,6 +447,12 @@ class TasksViewService:
         for dr in self.date_ranges_with_comparisons.values():  # pyright: ignore[reportAssignmentType]
             dr: DateRangeWithComparison = dr
             for date_range in [dr["date_range"], dr["comparison_date_range"]]:
+                if self.views_utils.is_view_calculated(date_range):
+                    print(
+                        f"Skipping calculation for {date_range['start'].date()} to {date_range['end'].date()} as it was already calculated."
+                    )
+                    continue
+
                 lf = self.get_view_date_range_data(date_range)
 
                 date_range_start_time = datetime.now()
@@ -461,11 +467,20 @@ class TasksViewService:
                 print(
                     f"  Finished in {format_timedelta(datetime.now() - date_range_start_time)}"
                 )
+                self.views_utils.set_view_calculated(date_range)
+
+        self.views_utils.clear_already_calculated_views()
 
     def insert_tasks_view_from_temp(self):
         for dr in self.date_ranges_with_comparisons.values():  # pyright: ignore[reportAssignmentType]
             dr: DateRangeWithComparison = dr
             for date_range in [dr["date_range"], dr["comparison_date_range"]]:
+                if self.views_utils.is_view_inserted(date_range):
+                    print(
+                        f"Skipping insertion for {date_range['start'].date()} to {date_range['end'].date()} as it was already inserted."
+                    )
+                    continue
+
                 date_range_start_time = datetime.now()
                 print(
                     f"Inserting tasks view for {date_range['start']} to {date_range['end']}..."
@@ -480,6 +495,9 @@ class TasksViewService:
                 print(
                     f"  Finished in {format_timedelta(datetime.now() - date_range_start_time)}"
                 )
+                self.views_utils.set_view_inserted(date_range)
+
+        self.views_utils.clear_already_inserted_views()
 
     def get_view_date_range_data(
         self,


### PR DESCRIPTION
# Summary | Résumé
Fixes two issues in mongo-parquet
- Using a list of file paths with `upload_to_remote` now functions correctly and doesn't modify the passed paths
- When calculating views, if date ranges are duplicated because they coincidentally have the same start and end dates as another date range, calculation and insertion will be skipped for already processed date ranges