### PR TITLE
feat: add scenario_id field to ux-test types and schemas

### DIFF
--- a/libs/db/src/lib/schemas/ux-test.schema.ts
+++ b/libs/db/src/lib/schemas/ux-test.schema.ts
@@ -49,6 +49,9 @@ export class UxTest implements IUxTest {
   scenario_html?: string;
 
   @Prop({ type: String })
+  scenario_id?: string;
+
+  @Prop({ type: String })
   vendor?: string;
 
   @Prop({ type: String })

--- a/libs/external-data/src/lib/airtable/index.ts
+++ b/libs/external-data/src/lib/airtable/index.ts
@@ -330,9 +330,9 @@ export class AirtableClient {
           session_type: Array.isArray(fields['Session Type'])
             ? fields['Session Type'][0]
             : undefined,
-          // scenario: fields['Scenario/Questions'],
           scenario: markdownToPlainText(rawScenario),
           scenario_html: markdownToSanitizedHtml(rawScenario),
+          scenario_id: fields['Scenario ID'],
           tasks: fields['Task'],
           subtask: fields['Sub-Task'],
           pages: fields['Pages_RecordIds'],

--- a/libs/external-data/src/lib/airtable/types.ts
+++ b/libs/external-data/src/lib/airtable/types.ts
@@ -60,6 +60,7 @@ export interface UxTestData {
   session_type?: string;
   scenario?: string;
   scenario_html?: string;
+  scenario_id?: string;
   tasks?: string[];
   pages?: string[];
   subtask?: string;

--- a/libs/types-common/src/lib/schema.types.ts
+++ b/libs/types-common/src/lib/schema.types.ts
@@ -344,6 +344,7 @@ export interface IUxTest {
   session_type?: string;
   scenario?: string;
   scenario_html?: string;
+  scenario_id?: string;
   vendor?: string;
   version_tested?: string;
   github_repo?: string;

--- a/python/mongo-parquet/src/mongo_parquet/schemas/ux_tests.py
+++ b/python/mongo-parquet/src/mongo_parquet/schemas/ux_tests.py
@@ -30,6 +30,7 @@ class UxTests(ParquetModel):
             "test_type": string(),
             "session_type": string(),
             "scenario": string(),
+            "scenario_id": string(),
             "scenario_html": string(),
             "vendor": string(),
             "version_tested": string(),


### PR DESCRIPTION
Cherry picked the commit adding scenario ids from staging, to get those isolated changes into main in order to get the required data before other updates are merged.