### PR TITLE
Refactor/tasks service caching

### DIFF
--- a/apps/api/src/overall/overall.module.ts
+++ b/apps/api/src/overall/overall.module.ts
@@ -7,7 +7,7 @@ import { hours } from '@dua-upd/utils-common';
 import { FeedbackModule } from '@dua-upd/api/feedback';
 
 @Module({
-  imports: [CacheModule.register({ ttl: hours(12) }), DbModule, FeedbackModule],
+  imports: [CacheModule.register({ ttl: hours(4) }), DbModule, FeedbackModule],
   controllers: [OverallController],
   providers: [OverallService],
 })

--- a/apps/api/src/overall/overall.service.ts
+++ b/apps/api/src/overall/overall.service.ts
@@ -53,7 +53,6 @@ import {
   avg,
   chunkMap,
   dateRangeSplit,
-  getAvgSuccessFromLatestTests,
   getImprovedKpiSuccessRates,
   getWosImprovedKpiSuccessRates,
   getImprovedKpiTopSuccessRates,
@@ -61,7 +60,6 @@ import {
   getStructuredDateRangesWithComparison,
   parseDateRangeString,
   percentChange,
-  addTmfScoresToTasks,
 } from '@dua-upd/utils-common';
 import { FeedbackService } from '@dua-upd/api/feedback';
 import { compressString, decompressString } from '@dua-upd/node-utils';
@@ -227,30 +225,7 @@ export class OverallService {
         parseDateRangeString(params.dateRange),
         parseDateRangeString(params.comparisonDateRange),
       )
-      .then((tasks) =>
-        addTmfScoresToTasks(tasks)
-          .slice(0, 50)
-          .map((taskData) => {
-            const { avgTestSuccess, percentChange: avgSuccessPercentChange } =
-              getAvgSuccessFromLatestTests(taskData.ux_tests);
-
-            const latest_success_rate_percent_change = percentChange(
-              avgTestSuccess,
-              avgTestSuccess - avgSuccessPercentChange,
-            );
-
-            const latest_success_rate_difference =
-              avgSuccessPercentChange * 100;
-
-            return {
-              ...taskData,
-              _id: taskData._id.toString(),
-              latest_ux_success: avgTestSuccess,
-              latest_success_rate_difference,
-              latest_success_rate_percent_change,
-            };
-          }),
-      );
+      .then((tasks) => tasks.filter(({ top_task }) => top_task));
     console.timeEnd('tasks');
 
     const results = {

--- a/apps/api/src/overall/overall.service.ts
+++ b/apps/api/src/overall/overall.service.ts
@@ -45,6 +45,7 @@ import type {
   OverallSearchTerm,
   PartialOverviewFeedback,
   ChunkedMostRelevantCommentsAndWords,
+  DateRange,
 } from '@dua-upd/types-common';
 import {
   $trunc,
@@ -210,7 +211,7 @@ export class OverallService {
     };
 
     const lastQuarterTopTaskIds =
-      await this.db.views.tasks.getTop50TaskIds(lastQuarterDateRange);
+      await this.getTop50TaskIds(lastQuarterDateRange);
 
     const improvedKpiTopSuccessRate = getImprovedKpiTopSuccessRates(
       lastQuarterTopTaskIds,
@@ -282,6 +283,26 @@ export class OverallService {
     );
 
     return results;
+  }
+
+  async getTop50TaskIds(dateRange: DateRange<Date>): Promise<string[]> {
+    const dateRangeStart = dateRange.start.toISOString().slice(0, 10);
+    const dateRangeEnd = dateRange.end.toISOString().slice(0, 10);
+    const top50CacheKey = `OverviewTop50TaskIds-${dateRangeStart}/${dateRangeEnd}`;
+
+    const cachedTop50 = await this.cacheManager.get<string[] | null>(
+      top50CacheKey,
+    );
+
+    if (cachedTop50 || cachedTop50 === null) {
+      return cachedTop50;
+    }
+
+    const top50TaskIds = await this.db.views.tasks.getTop50TaskIds(dateRange);
+
+    await this.cacheManager.set(top50CacheKey, top50TaskIds);
+
+    return top50TaskIds;
   }
 
   @AsyncLogTiming

--- a/apps/api/src/pages/pages.module.ts
+++ b/apps/api/src/pages/pages.module.ts
@@ -10,7 +10,7 @@ import { ExternalDataModule } from '@dua-upd/external-data';
 
 @Module({
   imports: [
-    CacheModule.register({ ttl: hours(12) }),
+    CacheModule.register({ ttl: hours(4) }),
     DbModule,
     FeedbackModule,
     FlowModule.register(),

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -7,7 +7,7 @@ import { hours } from '@dua-upd/utils-common';
 import { FeedbackModule } from '@dua-upd/api/feedback';
 
 @Module({
-  imports: [CacheModule.register({ ttl: hours(12) }), DbModule, FeedbackModule],
+  imports: [CacheModule.register({ ttl: hours(4) }), DbModule, FeedbackModule],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })

--- a/apps/api/src/reports/reports.module.ts
+++ b/apps/api/src/reports/reports.module.ts
@@ -6,7 +6,7 @@ import { ReportsService } from './reports.service';
 import { hours } from '@dua-upd/utils-common';
 
 @Module({
-  imports: [CacheModule.register({ ttl: hours(12) }), DbModule],
+  imports: [CacheModule.register({ ttl: hours(4) }), DbModule],
   controllers: [ReportsController],
   providers: [ReportsService],
 })

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -7,7 +7,7 @@ import { hours } from '@dua-upd/utils-common';
 import { FeedbackModule } from '@dua-upd/api/feedback';
 
 @Module({
-  imports: [CacheModule.register({ ttl: hours(12) }), DbModule, FeedbackModule],
+  imports: [CacheModule.register({ ttl: hours(4) }), DbModule, FeedbackModule],
   controllers: [TasksController],
   providers: [TasksService],
 })

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -12,54 +12,51 @@ import type {
 } from '@dua-upd/types-common';
 import {
   dateRangeSplit,
-  getAvgSuccessFromLatestTests,
   getLatestTaskSuccessRate,
   getSelectedPercentChange,
   parseDateRangeString,
   percentChange,
-  addTmfScoresToTasks,
+  type UnwrapPromise,
 } from '@dua-upd/utils-common';
 import { FeedbackService } from '@dua-upd/api/feedback';
 import { omit } from 'rambdax';
-import { compressString, decompressString } from '@dua-upd/node-utils';
 
 const DOCUMENTS_URL = () => process.env.DOCUMENTS_URL || '';
 
-type CachedTaskTmfRanking = {
-  taskId: string;
-  visits_score: number;
-  calls_score: number;
-  dyf_total_score: number;
-  survey_score: number;
-  overall_score: number;
-  tmf_rank: number;
+type ViewTaskType = UnwrapPromise<
+  ReturnType<DbService['views']['tasks']['getAllWithComparisons']>
+>[number];
+
+type TmfCacheValue = {
   tmf_total_tasks: number;
-  performance_score: number | null;
-  perf_rank: number | null;
   perf_total_tasks: number;
+  tmfTaskMap: Map<
+    string,
+    {
+      visits_score: number;
+      calls_score: number;
+      dyf_total_score: number;
+      survey_score: number;
+      overall_score: number;
+      tmf_rank: number;
+      performance_score: number | null;
+      perf_rank: number | null;
+    }
+  >;
 };
 
-type TmfRankedTaskLike = {
-  _id?: unknown;
-  task?: {
-    _id?: unknown;
-  };
-  visits_score?: number;
-  calls_score?: number;
-  dyf_total_score?: number;
-  survey_score?: number;
-  overall_score?: number;
-  tmf_rank?: number;
-  performance_score?: number | null;
-};
+const tasksHomeCacheKey = (
+  dateRangeString: string,
+  comparisonDateRangeString: string,
+) => `getTasksHomeData-${dateRangeString}-${comparisonDateRangeString}`;
+
+const tmfCacheKey = (
+  dateRangeString: string,
+  comparisonDateRangeString: string,
+) => `tmf-${dateRangeString}-${comparisonDateRangeString}`;
 
 @Injectable()
 export class TasksService {
-  private readonly tmfRankingCache = new Map<
-    string,
-    Map<string, CachedTaskTmfRanking>
-  >();
-
   constructor(
     private db: DbService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
@@ -67,38 +64,22 @@ export class TasksService {
   ) {}
 
   async getTasksHomeData(
-    dateRange: string,
-    comparisonDateRange: string,
+    dateRangeString: string,
+    comparisonDateRangeString: string,
   ): Promise<TasksHomeData> {
-    const cacheKey = this.getTasksHomeDataCacheKey(
-      dateRange,
-      comparisonDateRange,
+    const cacheKey = tasksHomeCacheKey(
+      dateRangeString,
+      comparisonDateRangeString,
     );
 
-    const cachedData = await this.cacheManager.get<string>(cacheKey).then(
-      async (cachedData) =>
-        cachedData &&
-        // it's actually still a string here, but we want to avoid deserializing it
-        // and then reserializing it to send over http while still keeping our types intact
-        ((await decompressString(cachedData)) as unknown as TasksHomeData),
-    );
+    const cachedData = await this.cacheManager.get<TasksHomeData>(cacheKey);
 
     if (cachedData) {
       return cachedData;
     }
 
-    const { start, end, comparisonStart, comparisonEnd } =
-      this.parseTasksHomeDateRanges(dateRange, comparisonDateRange);
-
-    const queryDateRange = {
-      start,
-      end,
-    };
-
-    const queryComparisonDateRange = {
-      start: comparisonStart,
-      end: comparisonEnd,
-    };
+    const dateRange = parseDateRangeString(dateRangeString);
+    const comparisonDateRange = parseDateRangeString(comparisonDateRangeString);
 
     const {
       totalCalls,
@@ -106,37 +87,20 @@ export class TasksService {
       totalVisits,
       totalVisitsPercentChange,
     } = await this.getTotalMetricsWithComparison(
-      queryDateRange,
-      queryComparisonDateRange,
-    );
-
-    console.time('tasks');
-
-    const tasksWithTmf = await this.getTasksWithTmfAndPrimeCache(
       dateRange,
       comparisonDateRange,
     );
 
-    const tasks = tasksWithTmf.map((task) => {
-      const { avgTestSuccess, percentChange: latest_success_rate } =
-        getAvgSuccessFromLatestTests(task.ux_tests);
+    console.time('tasks');
 
-      const latest_success_rate_percent_change = percentChange(
-        avgTestSuccess,
-        avgTestSuccess - latest_success_rate,
-      );
-
-      const latest_success_rate_difference = latest_success_rate * 100;
-
-      return {
-        ...task,
-        latest_ux_success: avgTestSuccess,
-        latest_success_rate_difference,
-        latest_success_rate_percent_change,
-      };
-    });
+    const tasks = await this.db.views.tasks.getAllWithComparisons(
+      dateRange,
+      comparisonDateRange,
+    );
 
     console.timeEnd('tasks');
+
+    await this.setTmfCache(dateRangeString, comparisonDateRangeString, tasks);
 
     const documentsUrl = DOCUMENTS_URL();
 
@@ -166,7 +130,7 @@ export class TasksService {
       )) as IReports[];
 
     const results = {
-      dateRange,
+      dateRange: dateRangeString,
       dateRangeData: tasks.map(omit(['ux_tests'])),
       totalVisits,
       percentChange: totalVisitsPercentChange,
@@ -175,220 +139,96 @@ export class TasksService {
       reports,
     };
 
-    await this.cacheManager.set(
-      cacheKey,
-      await compressString(JSON.stringify(results)),
-    );
+    await this.cacheManager.set(cacheKey, results);
 
     return results;
   }
 
-  private async getTasksWithTmfAndPrimeCache(
-    dateRange: string,
-    comparisonDateRange: string,
+  private async setTmfCache(
+    dateRangeString: string,
+    comparisonDateRangeString: string,
+    tasks: ViewTaskType[],
   ) {
-    const { start, end, comparisonStart, comparisonEnd } =
-      this.parseTasksHomeDateRanges(dateRange, comparisonDateRange);
+    const total_tasks = tasks.length;
+    const perf_total_tasks = tasks.filter(
+      (task) => !!task.performance_score,
+    ).length;
+    const tmfTaskMap = new Map(
+      tasks
+        .toSorted((a, b) => {
+          const scoreDiff =
+            (b.performance_score ?? 0) - (a.performance_score ?? 0);
 
-    const tasks = await this.db.views.tasks.getAllWithComparisons(
-      { start, end },
-      { start: comparisonStart, end: comparisonEnd },
+          if (scoreDiff !== 0) {
+            return scoreDiff;
+          }
+
+          return a.tmf_rank - b.tmf_rank;
+        })
+        .map((task, index) => [
+          task._id,
+          {
+            visits_score: task.visits_score,
+            calls_score: task.calls_score,
+            dyf_total_score: task.dyf_total_score,
+            survey_score: task.survey_score,
+            overall_score: task.overall_score,
+            tmf_rank: task.tmf_rank,
+            performance_score: task.performance_score || null,
+            perf_rank: task.performance_score ? index + 1 : null,
+          },
+        ]),
     );
 
-    const tasksWithTmf = addTmfScoresToTasks(tasks);
+    const cacheKey = tmfCacheKey(dateRangeString, comparisonDateRangeString);
 
-    this.setTmfRankingsCache(
-      dateRange,
-      comparisonDateRange,
-      tasksWithTmf as TmfRankedTaskLike[],
-    );
-
-    return tasksWithTmf;
+    await this.cacheManager.set(cacheKey, {
+      tmf_total_tasks: total_tasks,
+      perf_total_tasks,
+      tmfTaskMap,
+    });
   }
 
-  private async primeTmfRankingCache(
-    dateRange: string,
-    comparisonDateRange: string,
-  ): Promise<void> {
-    if (this.hasTmfRankingCache(dateRange, comparisonDateRange)) {
-      return;
-    }
-
-    const cachedHomeData = await this.getParsedCachedTasksHomeData(
-      dateRange,
-      comparisonDateRange,
-    );
-
-    if (cachedHomeData) {
-      this.setTmfRankingsCache(
-        dateRange,
-        comparisonDateRange,
-        cachedHomeData.dateRangeData as TmfRankedTaskLike[],
-      );
-
-      if (this.hasTmfRankingCache(dateRange, comparisonDateRange)) {
-        return;
-      }
-    }
-
-    await this.getTasksWithTmfAndPrimeCache(dateRange, comparisonDateRange);
-  }
-
-  private getTmfRankingFromCache(
-    dateRange: string,
-    comparisonDateRange: string,
+  private async getCachedTmfData(
     taskId: string,
-  ): CachedTaskTmfRanking | undefined {
-    return this.tmfRankingCache
-      .get(this.getTmfRankingCacheKey(dateRange, comparisonDateRange))
-      ?.get(taskId);
-  }
-
-  private hasTmfRankingCache(
-    dateRange: string,
-    comparisonDateRange: string,
-  ): boolean {
-    return this.tmfRankingCache.has(
-      this.getTmfRankingCacheKey(dateRange, comparisonDateRange),
-    );
-  }
-
-  private setTmfRankingsCache(
-    dateRange: string,
-    comparisonDateRange: string,
-    tasks: TmfRankedTaskLike[],
-  ): void {
-    const tmfTotalTasks = tasks.length;
-    const performanceRankByTaskId = this.getPerformanceRankByTaskId(tasks);
-    const perfTotalTasks = performanceRankByTaskId.size;
-
-    const rankings = tasks
-      .map((task) => {
-        const taskId = this.getTaskIdForTmfCache(task);
-
-        return this.toCachedTmfRanking(
-          task,
-          tmfTotalTasks,
-          taskId ? (performanceRankByTaskId.get(taskId) ?? null) : null,
-          perfTotalTasks,
-        );
-      })
-      .filter((ranking): ranking is CachedTaskTmfRanking => Boolean(ranking));
-
-    if (rankings.length === 0 && tasks.length > 0) {
-      return;
-    }
-
-    this.tmfRankingCache.set(
-      this.getTmfRankingCacheKey(dateRange, comparisonDateRange),
-      new Map(rankings.map((ranking) => [ranking.taskId, ranking])),
-    );
-  }
-
-  private toCachedTmfRanking(
-    task: TmfRankedTaskLike,
-    tmfTotalTasks: number,
-    perfRank: number | null,
-    perfTotalTasks: number,
-  ): CachedTaskTmfRanking | null {
-    const taskId = this.getTaskIdForTmfCache(task);
-
-    if (!taskId) {
-      return null;
-    }
-
-    const {
-      visits_score,
-      calls_score,
-      dyf_total_score,
-      survey_score,
-      overall_score,
-      tmf_rank,
-    } = task;
-
-    if (
-      typeof visits_score !== 'number' ||
-      typeof calls_score !== 'number' ||
-      typeof dyf_total_score !== 'number' ||
-      typeof survey_score !== 'number' ||
-      typeof overall_score !== 'number' ||
-      typeof tmf_rank !== 'number'
-    ) {
-      return null;
-    }
-
-    return {
-      taskId,
-      visits_score,
-      calls_score,
-      dyf_total_score,
-      survey_score,
-      overall_score,
-      tmf_rank,
-      tmf_total_tasks: tmfTotalTasks,
-      performance_score: this.getPerformanceScore(task),
-      perf_rank: perfRank,
-      perf_total_tasks: perfTotalTasks,
-    };
-  }
-
-  private getTaskIdForTmfCache(task: TmfRankedTaskLike): string | null {
-    const taskId = task.task?._id ?? task._id;
-
-    return taskId ? String(taskId) : null;
-  }
-
-  private getTmfRankingCacheKey(
-    dateRange: string,
-    comparisonDateRange: string,
-  ): string {
-    return `taskTmfRanking-${dateRange}-${comparisonDateRange}`;
-  }
-
-  private getTasksHomeDataCacheKey(
-    dateRange: string,
-    comparisonDateRange: string,
-  ): string {
-    return `getTasksHomeData-${dateRange}-${comparisonDateRange}`;
-  }
-
-  private async getParsedCachedTasksHomeData(
-    dateRange: string,
-    comparisonDateRange: string,
-  ): Promise<TasksHomeData | null> {
-    const cacheKey = this.getTasksHomeDataCacheKey(
-      dateRange,
-      comparisonDateRange,
-    );
-
-    const cachedData = await this.cacheManager.get<string>(cacheKey);
-
-    if (!cachedData) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(await decompressString(cachedData)) as TasksHomeData;
-    } catch {
-      return null;
-    }
-  }
-
-  private parseTasksHomeDateRanges(
-    dateRange: string,
-    comparisonDateRange: string,
+    dateRangeString: string,
+    comparisonDateRangeString: string,
   ) {
-    const [start, end] = dateRange.split('/').map((d) => new Date(d));
+    if (
+      !(await this.cacheManager.stores[0].has(
+        tasksHomeCacheKey(dateRangeString, comparisonDateRangeString),
+      ))
+    ) {
+      console.log(
+        `Cache miss for tasks home data for date range ${dateRangeString} and comparison date range ${comparisonDateRangeString}. Fetching and caching data...`,
+      );
+      await this.getTasksHomeData(dateRangeString, comparisonDateRangeString);
+    }
 
-    const [comparisonStart, comparisonEnd] = comparisonDateRange
-      .split('/')
-      .map((d) => new Date(d));
+    const cachedDateRangeData = await this.cacheManager.get<TmfCacheValue>(
+      tmfCacheKey(dateRangeString, comparisonDateRangeString),
+    );
+
+    // in theory, this should never actually happen
+    if (!cachedDateRangeData) {
+      throw new Error(
+        `No cached TMF data found for date range ${dateRangeString} and comparison date range ${comparisonDateRangeString}`,
+      );
+    }
+
+    const taskData = cachedDateRangeData.tmfTaskMap.get(taskId);
+
+    // this shouldn't happen either, unless the task id isn't valid, in which case an error should already be thrown
+    if (!taskData) {
+      throw new Error(
+        `No cached TMF data found for task id ${taskId} in date range ${dateRangeString} and comparison date range ${comparisonDateRangeString}`,
+      );
+    }
 
     return {
-      start,
-      end,
-      comparisonStart,
-      comparisonEnd,
+      ...taskData,
+      tmf_total_tasks: cachedDateRangeData.tmf_total_tasks,
+      perf_total_tasks: cachedDateRangeData.perf_total_tasks,
     };
   }
 
@@ -465,15 +305,20 @@ export class TasksService {
   }
 
   async getTaskDetails(params: ApiParams): Promise<TaskDetailsData> {
-    if (!params.id) {
+    if (!params || !params.id) {
       throw Error(
         'Attempted to get Task details from API but no id was provided.',
       );
     }
 
+    if (!params.comparisonDateRange) {
+      throw Error(
+        'Attempted to get Task details from API but no comparisonDateRange was provided.',
+      );
+    }
+
     const cacheKey = `getTaskDetails-${params.id}-${params.dateRange}-${params.comparisonDateRange}`;
-    const cachedData =
-      await this.cacheManager.get<TaskDetailsData>(cacheKey);
+    const cachedData = await this.cacheManager.get<TaskDetailsData>(cacheKey);
 
     if (cachedData) {
       return cachedData;
@@ -491,18 +336,11 @@ export class TasksService {
       { start: prevStart, end: prevEnd },
     );
 
-    await this.primeTmfRankingCache(
-      params.dateRange,
-      params.comparisonDateRange,
-    );
-
-    const tmfRanking = this.getTmfRankingFromCache(
-      params.dateRange,
-      params.comparisonDateRange,
+    const tmfData = await this.getCachedTmfData(
       params.id,
+      params.dateRange,
+      params.comparisonDateRange,
     );
-
-    const { taskId: _taskTmfId, ...tmfScoresAndRank } = tmfRanking ?? {};
 
     const commentsAndWords = await this.feedbackService.getCommentsAndWords({
       dateRange: parseDateRangeString(params.dateRange),
@@ -529,7 +367,7 @@ export class TasksService {
         : null;
 
     const uxTests = taskData.ux_tests
-      .map((uxTest) => ({
+      ?.map((uxTest) => ({
         _id: uxTest._id,
         _project_id: uxTest.project,
         title: uxTest.title,
@@ -541,23 +379,24 @@ export class TasksService {
         scenario_html: uxTest.scenario_html,
       }))
       .sort((a, b) => {
-        if (a.date < b.date) return 1;
-        if (a.date > b.date) return -1;
+        // send null dates to the end of the list
+        if ((a.date || Infinity) < (b.date || Infinity)) return 1;
+        if ((a.date || Infinity) > (b.date || Infinity)) return -1;
         return 0;
       });
 
-    const taskSuccessByUxTest = uxTests;
+    const taskSuccessByUxTest = uxTests || [];
 
     const {
       avgTestSuccess: avgTaskSuccessFromLastTest,
       latestDate: dateFromLastTest,
       percentChange: avgSuccessPercentChange,
       valueChange: avgSuccessValueChange,
-    } = getLatestTaskSuccessRate(uxTests);
+    } = getLatestTaskSuccessRate(uxTests || []);
 
     const returnData = {
       ...omit(['ux_tests'], taskData),
-      ...tmfScoresAndRank,
+      ...tmfData,
       dateRange: params.dateRange,
       comparisonDateRange: params.comparisonDateRange,
       taskSuccessByUxTest,
@@ -568,53 +407,10 @@ export class TasksService {
       commentsAndWords,
       numComments,
       numCommentsPercentChange,
-    };
+    } satisfies TaskDetailsData;
 
-    // await this.cacheManager.set(cacheKey, returnData);
+    await this.cacheManager.set(cacheKey, returnData);
 
     return returnData;
-  }
-
-  private getPerformanceRankByTaskId(
-    tasks: TmfRankedTaskLike[],
-  ): Map<string, number> {
-    const rankedPerformanceTasks = tasks
-      .map((task) => ({
-        taskId: this.getTaskIdForTmfCache(task),
-        performanceScore: this.getPerformanceScore(task),
-        tmfRank:
-          typeof task.tmf_rank === 'number'
-            ? task.tmf_rank
-            : Number.POSITIVE_INFINITY,
-      }))
-      .filter(
-        (
-          task,
-        ): task is {
-          taskId: string;
-          performanceScore: number;
-          tmfRank: number;
-        } => !!task.taskId && task.performanceScore !== null,
-      )
-      .sort((a, b) => {
-        const scoreDiff = b.performanceScore - a.performanceScore;
-
-        if (scoreDiff !== 0) {
-          return scoreDiff;
-        }
-
-        return a.tmfRank - b.tmfRank;
-      });
-
-    return new Map(
-      rankedPerformanceTasks.map((task, index) => [task.taskId, index + 1]),
-    );
-  }
-
-  private getPerformanceScore(task: TmfRankedTaskLike): number | null {
-    return typeof task.performance_score === 'number' &&
-      Number.isFinite(task.performance_score)
-      ? task.performance_score
-      : null;
   }
 }

--- a/libs/db/src/lib/views/tasks.view.ts
+++ b/libs/db/src/lib/views/tasks.view.ts
@@ -22,13 +22,16 @@ import type {
 } from '@dua-upd/types-common';
 import {
   $trunc,
+  addTmfScoresToTasks,
   arrayToDictionary,
   arrayToDictionaryMultiref,
   getArraySelectedAbsoluteChange,
   getArraySelectedPercentChange,
+  getAvgSuccessFromLatestTests,
   getSelectedAbsoluteChange,
   getSelectedPercentChange,
   isNullish,
+  percentChange,
   sum,
 } from '@dua-upd/utils-common';
 import { DbService } from '../db.service';
@@ -905,7 +908,6 @@ export class TasksViewService extends DbViewNew<
       performance_score: number | null;
       historical_average: number | null;
       seasonal_average: number | null;
-      performance_score_status: string;
       individual_status: string;
       cops: boolean;
       wos_cops: boolean;
@@ -935,13 +937,14 @@ export class TasksViewService extends DbViewNew<
     };
 
     const projection: PipelineStage.Project['$project'] = {
-      _id: '$task._id',
+      _id: {
+        $toString: '$task._id',
+      },
       title: '$task.title',
       tmf_ranking_index: 1,
       performance_score: 1,
       historical_average: 1,
       seasonal_average: 1,
-      performance_score_status: 1,
       individual_status: 1,
       cops: 1,
       wos_cops: 1,
@@ -1004,15 +1007,19 @@ export class TasksViewService extends DbViewNew<
         .project(projection)
         .exec()
         .then((results) =>
-          results
-            .sort((a, b) => {
-              const aIfActive =
-                a.status === 'Inactive' ? 0 : a.tmf_ranking_index;
-              const bIfActive =
-                b.status === 'Inactive' ? 0 : b.tmf_ranking_index;
-              return bIfActive - aIfActive;
-            })
-            .map((task, i) => ({
+          // `addTmfScoresToTasks` already sorts the tasks by TMF score, so no need to sort here
+          addTmfScoresToTasks(results).map((task, i) => {
+            const { avgTestSuccess, percentChange: latest_success_rate } =
+              getAvgSuccessFromLatestTests(task.ux_tests);
+
+            const latest_success_rate_percent_change = percentChange(
+              avgTestSuccess,
+              avgTestSuccess - latest_success_rate,
+            );
+
+            const latest_success_rate_difference = latest_success_rate * 100;
+
+            return {
               ...task,
               tmf_rank: i + 1,
               top_task: i < 50,
@@ -1022,7 +1029,11 @@ export class TasksViewService extends DbViewNew<
               ux_testing: !!task.ux_tests?.find(
                 (test) => !isNullish(test.success_rate),
               ),
-            })),
+              latest_ux_success: avgTestSuccess,
+              latest_success_rate_difference,
+              latest_success_rate_percent_change,
+            };
+          }),
         ),
       this.aggregate<ProjectedTask>({ dateRange: comparisonDateRange })
         .project(projection)

--- a/libs/db/src/lib/views/tasks.view.ts
+++ b/libs/db/src/lib/views/tasks.view.ts
@@ -902,7 +902,7 @@ export class TasksViewService extends DbViewNew<
     comparisonDateRange: DateRange<Date>,
   ) {
     type ProjectedTask = {
-      _id: Types.ObjectId;
+      _id: string;
       title: string;
       tmf_ranking_index: number;
       performance_score: number | null;

--- a/libs/db/src/lib/views/tasks.view.ts
+++ b/libs/db/src/lib/views/tasks.view.ts
@@ -607,23 +607,39 @@ export class TasksViewService extends DbViewNew<
     return super.aggregate<T>(filter, options);
   }
 
-  async getTop50TaskIds(dateRange: { start: Date; end: Date }) {
+  async getTop50TaskIds(dateRange: {
+    start: Date;
+    end: Date;
+  }): Promise<string[] | null> {
     return await this._model
       .aggregate<{
-        _id: Types.ObjectId;
+        _id: string;
+        visits: number;
+        calls: number;
+        dyf_total: number;
+        survey: number;
+        status: string;
       }>()
       .match({
         dateRange,
       })
-      .sort({
-        tmf_ranking_index: -1,
-      })
-      .limit(50)
       .project({
-        _id: '$task._id',
+        _id: {
+          $toString: '$task._id',
+        },
+        visits: 1,
+        calls: 1,
+        dyf_total: 1,
+        survey: 1,
+        status: 1,
       })
       .exec()
-      .then((results) => results.map(({ _id }) => _id.toString()));
+      .then((results) =>
+        // `addTmfScoresToTasks` already sorts the tasks by TMF score, so no need to sort here
+        addTmfScoresToTasks(results)
+          .slice(0, 50)
+          .map((task) => task._id),
+      );
   }
 
   async getTaskMetricsWithComparisons(

--- a/libs/types-common/src/lib/data.types.ts
+++ b/libs/types-common/src/lib/data.types.ts
@@ -363,15 +363,15 @@ export interface TasksHomeAggregatedData {
   calls: number;
   dyf_no: number;
   dyf_yes: number;
-  latest_ux_success: number;
+  latest_ux_success: number | null;
   survey: number;
   survey_percent_change: number | null;
   survey_difference: number | null;
-  survey_completed: number;
+  survey_completed: number | null;
   survey_completed_percent_change: number | null;
   survey_completed_difference: number | null;
-  calls_per_100_visits: number;
-  dyf_no_per_1000_visits: number;
+  calls_per_100_visits: number | null;
+  dyf_no_per_1000_visits: number | null;
   calls_per_100_visits_difference: number | null;
   dyf_no_per_1000_visits_difference: number | null;
   calls_percent_change: number | null;
@@ -399,16 +399,16 @@ export interface TasksHomeAggregatedData {
 
 export type TasksHomeData = ViewData<TasksHomeAggregatedData[]> & {
   totalVisits: number;
-  percentChange: number;
+  percentChange: number | null;
   totalCalls: number;
-  percentChangeCalls: number;
+  percentChangeCalls: number | null;
   reports: IReports[];
 };
 
 export interface TaskDetailsMetrics {
   calldriversEnquiry: { enquiry_line: string; calls: number }[];
-  callsPer100VisitsByDay: { date: string; calls: number }[];
-  dyfNoPer1000VisitsByDay: { date: string; dyfNo: number }[];
+  callsPer100VisitsByDay: { date: string; calls: number | null }[];
+  dyfNoPer1000VisitsByDay: { date: string; dyfNo: number | null }[];
   dyfYes: number;
   dyfNo: number;
   individualHistory?: {
@@ -452,18 +452,18 @@ export interface TaskDetailsData extends EntityDetailsData<TaskDetailsMetrics> {
   gscTotalCtrPercentChange?: number | null;
   gscTotalPosition?: number;
   gscTotalPositionPercentChange?: number | null;
-  avgTaskSuccessFromLastTest: number;
-  avgSuccessPercentChange: number;
-  avgSuccessValueChange: number;
-  dateFromLastTest: Date;
+  avgTaskSuccessFromLastTest: number | null;
+  avgSuccessPercentChange: number | null;
+  avgSuccessValueChange: number | null;
+  dateFromLastTest: Date | null;
   taskSuccessByUxTest: {
     title: string;
-    date: Date;
-    test_type: string;
-    success_rate: number | null;
-    total_users: number;
-    scenario: string;
-    scenario_html: string;
+    date?: Date | undefined;
+    test_type?: string | undefined;
+    success_rate?: number | undefined;
+    total_users?: number | undefined;
+    scenario?: string | undefined;
+    scenario_html?: string | undefined;
   }[];
   projects: {
     _id: string;
@@ -493,8 +493,8 @@ export interface TaskDetailsData extends EntityDetailsData<TaskDetailsMetrics> {
     gscTotalImpressions: number;
     gscTotalCtr: number;
     gscTotalPosition: number;
-    owners: string;
-    sections: string;
+    owners: string | undefined;
+    sections: string | undefined;
     numComments: number;
     numCommentsPercentChange: number | null;
   }[];

--- a/libs/upd/views/tasks/src/lib/task-details/+state/tasks-details.selectors.ts
+++ b/libs/upd/views/tasks/src/lib/task-details/+state/tasks-details.selectors.ts
@@ -100,11 +100,12 @@ export const selectCallsPerVisitsChartData = createSelector(
     const comparisonCallsByDay =
       comparisonDateRangeData?.callsPer100VisitsByDay || [];
 
-    const callsPerVisitsSeries = callsByDay.map(({ date, calls }) => ({
-      x: date,
-      y: calls,
-    }))
-    .filter(({ y }) => y);
+    const callsPerVisitsSeries = callsByDay
+      .map(({ date, calls }) => ({
+        x: date,
+        y: calls,
+      }))
+      .filter(({ y }) => y);
 
     const comparisonCallsPerVisitsSeries = comparisonCallsByDay
       .filter(({ date }) => dates.has(date))
@@ -115,10 +116,12 @@ export const selectCallsPerVisitsChartData = createSelector(
       .filter(({ y }) => y);
 
     const isCallsPerVisitsEmpty = callsPerVisitsSeries.every(
-      ({ y }) => y === 0 || isNaN(y),
+      ({ y }) => y === 0 || Number.isNaN(y),
     );
     const isComparisonCallsPerVisitsEmpty =
-      comparisonCallsPerVisitsSeries.every(({ y }) => y === 0 || isNaN(y));
+      comparisonCallsPerVisitsSeries.every(
+        ({ y }) => y === 0 || Number.isNaN(y),
+      );
 
     if (isCallsPerVisitsEmpty && isComparisonCallsPerVisitsEmpty) {
       return [];
@@ -168,10 +171,12 @@ export const selectDyfNoPerVisitsSeries = createSelector(
       .filter(({ x }) => x);
 
     const isDyfNoPerVisitsEmpty = dyfNoPerVisitsSeries.every(
-      ({ y }) => y === 0 || isNaN(y),
+      ({ y }) => y === 0 || Number.isNaN(y),
     );
     const isComparisonDyfNoPerVisitsEmpty =
-      comparisonDyfNoPerVisitsSeries.every(({ y }) => y === 0 || isNaN(y));
+      comparisonDyfNoPerVisitsSeries.every(
+        ({ y }) => y === 0 || Number.isNaN(y),
+      );
 
     if (isDyfNoPerVisitsEmpty && isComparisonDyfNoPerVisitsEmpty) {
       return [];


### PR DESCRIPTION
Just read the commit messages.

or:

# SUPER LONG COPILOT DESCRIPTIONS:
This pull request makes several important changes to how top tasks are queried, processed, and cached, as well as improves data consistency and error handling in task-related data structures and selectors. The main themes are improvements to data processing for top tasks, cache configuration adjustments, and stricter typing for optional data fields.

**Top tasks processing and caching improvements:**

* Refactored the retrieval of top 50 task IDs to use a new `getTop50TaskIds` method in `OverallService`, which caches results for each date range and ensures consistent sorting using `addTmfScoresToTasks`. This improves performance and ensures the top tasks are always ranked by TMF score. [[1]](diffhunk://#diff-f93321de4dbc9ece9487e86d21ad4b7a4853fa64fe5929ce7edc02b67377fccfL215-R214) [[2]](diffhunk://#diff-f93321de4dbc9ece9487e86d21ad4b7a4853fa64fe5929ce7edc02b67377fccfR288-R307) [[3]](diffhunk://#diff-fc99391ab8e1d9fc4a4618eb7f4348efc0057d2a8ed0b6d4d3101aa660608375L607-R642)
* Updated the `getTop50TaskIds` method in `TasksViewService` to project task IDs as strings, add necessary fields, and use `addTmfScoresToTasks` for sorting and slicing, removing redundant sorting logic.
* Improved the aggregation of task metrics to use string IDs, add latest UX success metrics, and consistently apply TMF ranking and filtering logic. [[1]](diffhunk://#diff-fc99391ab8e1d9fc4a4618eb7f4348efc0057d2a8ed0b6d4d3101aa660608375L902-L908) [[2]](diffhunk://#diff-fc99391ab8e1d9fc4a4618eb7f4348efc0057d2a8ed0b6d4d3101aa660608375L938-L944) [[3]](diffhunk://#diff-fc99391ab8e1d9fc4a4618eb7f4348efc0057d2a8ed0b6d4d3101aa660608375L1007-R1038) [[4]](diffhunk://#diff-fc99391ab8e1d9fc4a4618eb7f4348efc0057d2a8ed0b6d4d3101aa660608375L1025-R1052)
* Removed redundant or unnecessary data processing steps in `OverallService`, such as extra mapping and calculation of UX success rates, since these are now handled in the DB view.

**Cache configuration changes:**

* Reduced the cache TTL from 12 hours to 4 hours across all main modules using the `CacheModule`, including `overall`, `pages`, `projects`, `reports`, and `tasks` modules, to ensure fresher data. [[1]](diffhunk://#diff-4ab3ef62a2e39549a795b235272caeedf490341dcd6a433728800bd2f0f719d2L10-R10) [[2]](diffhunk://#diff-bc86fbe63d841e3ab979491ca21695c65bf5cf2681e2dc9424e4df1f0cb3d838L13-R13) [[3]](diffhunk://#diff-6cb1b45077b658257cf14384bab8f2839fe85ab97410999edd53a2d9399faaf9L10-R10) [[4]](diffhunk://#diff-401dadeb38e5631e5522e5aefa8242b36ffa328df3a4b847984876355f00da3eL9-R9) [[5]](diffhunk://#diff-cab4bb8a2d21cd32306dd7e0fc8a1878f1978444bd1b5dfc1c779ce52f6aa3e7L10-R10)

**Type and data consistency improvements:**

* Updated several fields in `TasksHomeAggregatedData`, `TasksHomeData`, and `TaskDetailsData` to allow `null` or `undefined` values, improving robustness in cases where data is missing or incomplete. [[1]](diffhunk://#diff-48068dc203c76fcfd9a6913d6a28eaddb3fa103fedccbaa5d3c3cea92cff660cL366-R374) [[2]](diffhunk://#diff-48068dc203c76fcfd9a6913d6a28eaddb3fa103fedccbaa5d3c3cea92cff660cL402-R411) [[3]](diffhunk://#diff-48068dc203c76fcfd9a6913d6a28eaddb3fa103fedccbaa5d3c3cea92cff660cL455-R466) [[4]](diffhunk://#diff-48068dc203c76fcfd9a6913d6a28eaddb3fa103fedccbaa5d3c3cea92cff660cL496-R497)
* Improved selectors for task details charts to handle `null` values and use `Number.isNaN` for more accurate empty data detection. [[1]](diffhunk://#diff-29a435640fb03bcd3c3e5b616ab6031059144c37c9485f630e2780f7f4a65debL103-R104) [[2]](diffhunk://#diff-29a435640fb03bcd3c3e5b616ab6031059144c37c9485f630e2780f7f4a65debL118-R124) [[3]](diffhunk://#diff-29a435640fb03bcd3c3e5b616ab6031059144c37c9485f630e2780f7f4a65debL171-R179)

**Dependency and import updates:**

* Cleaned up imports in `overall.service.ts` and `tasks.view.ts`, removing unused utility functions and adding only those required for the new logic. [[1]](diffhunk://#diff-f93321de4dbc9ece9487e86d21ad4b7a4853fa64fe5929ce7edc02b67377fccfR48) [[2]](diffhunk://#diff-f93321de4dbc9ece9487e86d21ad4b7a4853fa64fe5929ce7edc02b67377fccfL56-L64) [[3]](diffhunk://#diff-fc99391ab8e1d9fc4a4618eb7f4348efc0057d2a8ed0b6d4d3101aa660608375R25-R34)